### PR TITLE
feat(event): re-implement check-in event API (by GPS, QR Code)

### DIFF
--- a/src/main/java/com/example/MiniEvent/adapter/repository/FireBaseEventRepository.java
+++ b/src/main/java/com/example/MiniEvent/adapter/repository/FireBaseEventRepository.java
@@ -54,7 +54,7 @@ public class FireBaseEventRepository implements EventRepository{
 
         Query query = firestore.collection("events")
                 .whereEqualTo("privateEvent", false)
-                .whereGreaterThan("date", firestoreTimestamp)
+                .whereLessThan("date", firestoreTimestamp)
                 .orderBy("date")
                 .limit(pageSize);
         try {
@@ -81,7 +81,7 @@ public class FireBaseEventRepository implements EventRepository{
         Query query = firestore.collection("events")
                 .whereEqualTo("privateEvent", false)
                 .whereEqualTo("eventTag", eventTag.name())
-//                .whereGreaterThan("date", firestoreTimestamp)
+                .whereLessThan("date", firestoreTimestamp)
                 .orderBy("date")
                 .limit(pageSize);
         try {

--- a/src/main/java/com/example/MiniEvent/adapter/web/dto/request/UpdateEventRequestDTO.java
+++ b/src/main/java/com/example/MiniEvent/adapter/web/dto/request/UpdateEventRequestDTO.java
@@ -9,7 +9,7 @@ import org.springframework.web.multipart.MultipartFile;
 @AllArgsConstructor
 @Builder
 public class UpdateEventRequestDTO {
-    private String idToken;
+    private String userId;
     private String eventId;
     private UpdateEventRequest request;
     private MultipartFile image;

--- a/src/main/java/com/example/MiniEvent/model/entity/Checkin.java
+++ b/src/main/java/com/example/MiniEvent/model/entity/Checkin.java
@@ -19,4 +19,5 @@ public class Checkin {
     private String eventId;
     private GeoPoint location;
     private Date date;
+    private CheckinMethod checkinMethod;
 }

--- a/src/main/java/com/example/MiniEvent/model/entity/CheckinMethod.java
+++ b/src/main/java/com/example/MiniEvent/model/entity/CheckinMethod.java
@@ -1,0 +1,16 @@
+package com.example.MiniEvent.model.entity;
+
+import lombok.Getter;
+
+@Getter
+public enum CheckinMethod {
+    GPS("check-in by GPS"),
+    QR("check-in by QR");
+
+    private final String description;
+
+    CheckinMethod(String description) {
+        this.description = description;
+    }
+
+}

--- a/src/main/java/com/example/MiniEvent/service/impl/ZXingQRCodeGenService.java
+++ b/src/main/java/com/example/MiniEvent/service/impl/ZXingQRCodeGenService.java
@@ -58,6 +58,19 @@ public class ZXingQRCodeGenService implements QRCodeGenService {
         }
     }
 
+    @Override
+    public QRCodeData getData(String token) {
+        try {
+            Claims claims = parseJwt(token);
+            String userId = claims.get("userId", String.class);
+            String eventId = claims.get("eventId", String.class);
+            return new QRCodeData(userId, eventId);
+        }
+        catch (Exception e) {
+            throw new RuntimeException("Error in get data QR Code");
+        }
+    }
+
     private Claims parseJwt(String token) {
         try {
             return Jwts.parser()

--- a/src/main/java/com/example/MiniEvent/service/inteface/QRCodeGenService.java
+++ b/src/main/java/com/example/MiniEvent/service/inteface/QRCodeGenService.java
@@ -6,5 +6,7 @@ import com.example.MiniEvent.model.entity.QRCodeData;
 import java.awt.image.BufferedImage;
 
 public interface QRCodeGenService {
-    public BufferedImage generateQRCodeImage(QRCodeData qrCodeData);
+    BufferedImage generateQRCodeImage(QRCodeData qrCodeData);
+    QRCodeData getData(String token);
+
 }

--- a/src/main/java/com/example/MiniEvent/usecase/impl/UpdateEventUseCaseImpl.java
+++ b/src/main/java/com/example/MiniEvent/usecase/impl/UpdateEventUseCaseImpl.java
@@ -21,19 +21,15 @@ public class UpdateEventUseCaseImpl implements UpdateEventUseCase {
 
     private final EventRepository eventRepository;
     private final EventMapper eventMapper;
-    private final AuthService authService;
     private final ImageStorageService imageStorageService;
 
     @Override
     public Event updateEvent(UpdateEventRequestDTO updateEventRequestDTO) {
 
-        DecodedTokenInfo decodedToken = authService.verifyToken(updateEventRequestDTO.getIdToken());
-        String uid = decodedToken.getUid();
-
         Event event = eventRepository.findById(updateEventRequestDTO.getEventId())
                 .orElseThrow(() -> new DataNotFoundException("Event not found", HttpStatus.NOT_FOUND));
 
-        if (!event.getCreatedBy().equals(uid)) {
+        if (!event.getCreatedBy().equals(updateEventRequestDTO.getUserId())) {
             throw new ForbiddenException("You are not allowed to update this event", HttpStatus.FORBIDDEN);
         }
 

--- a/src/main/java/com/example/MiniEvent/usecase/inteface/CheckinEventUseCase.java
+++ b/src/main/java/com/example/MiniEvent/usecase/inteface/CheckinEventUseCase.java
@@ -1,7 +1,9 @@
 package com.example.MiniEvent.usecase.inteface;
 
 import com.example.MiniEvent.adapter.web.dto.request.CheckinRequest;
+import com.example.MiniEvent.model.entity.Checkin;
 
 public interface CheckinEventUseCase {
-    Boolean CheckinEventGPS(CheckinRequest checkinRequest, String eventId, String userId);
+    Checkin CheckinEventGPS(CheckinRequest checkinRequest, String eventId, String userId);
+    Checkin CheckinEventQR(String token, String eventId);
 }

--- a/src/test/java/com/example/MiniEvent/usecase/EventUseCaseTest.java
+++ b/src/test/java/com/example/MiniEvent/usecase/EventUseCaseTest.java
@@ -140,12 +140,11 @@ public class EventUseCaseTest {
         GeoPoint updateLocation = new GeoPoint(11.7769,13.7009);
         Timestamp updateDate = Timestamp.ofTimeMicroseconds(1745147570000000L);
         UpdateEventRequest updateEventRequest = new UpdateEventRequest("update event", updateLocation, "A update test event", updateDate, true, true, 30,null,null);
-        UpdateEventRequestDTO updateEventRequestDTO = new UpdateEventRequestDTO(idToken, eventId, updateEventRequest, null);
+        UpdateEventRequestDTO updateEventRequestDTO = new UpdateEventRequestDTO(uid, eventId, updateEventRequest, null);
         DecodedTokenInfo decodedTokenInfo = mock(DecodedTokenInfo.class);
 
 
         when(decodedTokenInfo.getUid()).thenReturn(uid);
-        when(authService.verifyToken(idToken)).thenReturn(decodedTokenInfo);
         when(eventRepository.findById("event123")).thenReturn(Optional.ofNullable(event));
         doAnswer(invocation -> {
             event.setName(updateEventRequest.getName());
@@ -162,7 +161,6 @@ public class EventUseCaseTest {
         assertEquals("update event", updatedEvent.getName());
         assertEquals("A update test event", updatedEvent.getDescription());
 
-        verify(authService).verifyToken(idToken);
         verify(eventRepository).findById(eventId);
         verify(eventRepository).save(event);
         verify(imageStorageService, never()).uploadImage((MultipartFile) any());


### PR DESCRIPTION
### What does this PR do?

Re-implement the event check-in API with support for both GPS-based and QR code-based methods.

### Changes made:
- Added QR code check-in feature: validates a unique token from QR scan.
- Updated request DTOs and service layer to support both check-in types.
- Added exception handling for invalid or expired QR tokens.
- Adjusted controller routes to unify check-in endpoint logic.
- Order event by descending when get list event public

### Notes:
- The QR check-in flow assumes the client scans a QR code and sends a token to the server.
- GPS check-in verifies user's current location against event location within a radius.
- This change deprecates the previous GPS-only check-in method.
